### PR TITLE
CactusTutorial.ipynb: Add kuibit

### DIFF
--- a/tutorial-server/notebooks/CactusTutorial.ipynb
+++ b/tutorial-server/notebooks/CactusTutorial.ipynb
@@ -6,9 +6,9 @@
    "source": [
     "<h2>Introduction</h2>\n",
     "\n",
-    "Here you will find a step by step guide to downloading, configuring, and running the Einstein Toolkit. You may use this tutorial on a workstation or laptop, or on a supported cluster. Configuring the Einstein Toolkit on an unsupported cluster is beyond the scope of this tutorial. If you prefer to use it instead, a [video recording](https://icerm.brown.edu/video_archive/?play=2356) is available. If you find something that does not work, please feel free to email users@einsteintoolkit.org.\n",
+    "Here you will find a step by step guide to downloading, configuring, and running the Einstein Toolkit. You may use this tutorial on a workstation or laptop, or on a supported cluster. Configuring the Einstein Toolkit on an unsupported cluster is beyond the scope of this tutorial. If you find something that does not work, please feel free to email users@einsteintoolkit.org.\n",
     "\n",
-    "This tutorial is very basic and does not describe the internal workings of the Einstein Toolkit. For a more detailed introduction, please have a look a the [text](https://arxiv.org/abs/1305.5299) provided by Miguel Zilhão and Frank Löffler and the [one](https://arxiv.org/abs/2011.13314) by  Nicholas Choustikov."
+    "This tutorial is very basic and does not describe the internal workings of the Einstein Toolkit. For a more detailed introduction, please have a look a the [text](https://arxiv.org/abs/1305.5299) provided by Miguel Zilhão and Frank Löffler and the [one](https://arxiv.org/abs/2011.13314) by Nicholas Choustikov."
    ]
   },
   {
@@ -101,7 +101,36 @@
     "os.environ[\"OMPI_MCA_rmaps_base_oversubscribe\"] = \"true\"\n",
     "os.environ[\"OMPI_MCA_hwloc_base_binding_policy\"] = \"none\"\n",
     "os.environ[\"OMPI_MCA_btl_vader_single_copy_mechanism\"] = \"none\"\n",
-    "import scrolldown"
+    "\n",
+    "try:\n",
+    "    import scrolldown\n",
+    "except ModuleNotFoundError: \n",
+    "    pass\n",
+    "\n",
+    "# We are going to install kuibit, a Python package to post-process Cactus simulations.\n",
+    "# We will install kuibit inside the Cactus directory. The main reason for this is to\n",
+    "# have a make easier to uninstall kuibit (you can just remove the Cactus folder). \n",
+    "os.environ[\"PYTHONUSERBASE\"] = os.path.join(os.environ[\"HOME\"], \"Cactus\")\n",
+    "\n",
+    "# The following function is needed to work with pip\n",
+    "def reload_userbasepath():\n",
+    "    os.environ[\"PYTHONUSERBASE\"] = os.path.join(os.environ[\"HOME\"], \"Cactus\")\n",
+    "    \n",
+    "    # Force the re-evaluation of PYTHONUSERBASE\n",
+    "    # see https://github.com/nds-org/jupyter-et/pull/17#discussion_r789113337\n",
+    "    import site\n",
+    "    site.USER_SITE = None\n",
+    "    site.USER_BASE = None\n",
+    "    site.main()\n",
+    "\n",
+    "# We will need to find the path of the directory where the simulation data is saved.\n",
+    "# This is a convenience function to do this in full generality. \n",
+    "# This is here to keep the tutorial working on several different setups. \n",
+    "def get_datadir(sim_name):\n",
+    "    # Ask simfactory where the latest output was writted\n",
+    "    datadir = os.popen(f\"./simfactory/bin/sim get-output-dir {sim_name}\").read().rstrip(\"\\\\n\")\n",
+    "    # Remove the /output-XXXX part\n",
+    "    return os.path.split(datadir)[0]"
    ]
   },
   {
@@ -729,7 +758,102 @@
    "source": [
     "<h2>Plotting the Output</h2>\n",
     "\n",
-    "The following commands will generate a simple line plot of the data. They will work in a python script as easily as they do in the notebook (just remove the \"%matplotlib inline\" directive)."
+    "The simplest way to analyze a simulation is using [kuibit](https://sbozzolo.github.io/kuibit/). a Python package for post-processing and visualization. `kuibit` is part of the Einstein Toolkit, but has to be installed separately. You can install `kuibit` with `pip3`. This will take care of all the required dependencies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "# We install kuibit inside the Cactus folder so that if you wish to\n",
+    "# remove kuibit you can simply remove the folder. You can ignore the\n",
+    "# following line if you want to install kuibit along your other python\n",
+    "# packages.\n",
+    "export PYTHONUSERBASE=\"$HOME/Cactus\"\n",
+    "pip3 install -U --user kuibit==1.3.3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`kuibit` is a Python library: you can use it in Python scripts/notebooks to inspect and post-process your simulations. `kuibit` has rich [documentation](https://sbozzolo.github.io/kuibit) and tutorials to get use the package. Here, we are going to show only a few features.\n",
+    "\n",
+    "The Einstein Toolkit comes with several [kuibit examples](https://sbozzolo.github.io/kuibit/#examples) that are ready to be used. The examples are available in the `utils/Analysis/kuibit/examples` folder. Most of these codes are command-line scripts that produce plots. \n",
+    "\n",
+    "For example, two common plots are for timeseries and for grid variables. For those, we can use the `plot_timeseries.py` and `plot_grid_var.py` codes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "# See comment before\n",
+    "export PYTHONUSERBASE=\"$HOME/Cactus\"\n",
+    "\n",
+    "# Here we define a bash variable that contains the path where\n",
+    "# the simulation data lives. We do so to keep this tutorial general.\n",
+    "# Normally you would just input the path or you would run the\n",
+    "# script directly from the data directory.\n",
+    "datadir=$(dirname $(./simfactory/bin/sim get-output-dir tov_ET))\n",
+    "\n",
+    "# Plot a timeseries with the maximum of the density\n",
+    "./utils/Analysis/kuibit/examples/bins/plot_timeseries.py --datadir $datadir \\\n",
+    "--variable \"rho\" --reduction \"maximum\" --outdir $datadir\n",
+    "\n",
+    "# Plot a 2D slice of the rest-mass density (which does not support reflection \n",
+    "# symmetry, see below). \n",
+    "#`-x0` and `-x1` define the region we want to plot: they coordinates of the \n",
+    "# lower left and top right corners. \n",
+    "#When not specified, the latest available iteration is plotted. \n",
+    "./utils/Analysis/kuibit/examples/bins/plot_grid_var.py --datadir $datadir \\\n",
+    "--variable \"rho\" -x0 0 0 -x1 10 10 --outdir $datadir --logscale --multilinear-interpolate \\\n",
+    "--colorbar"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The outputs are two images named `rho_maximum.png` and `rho_xy.png` saved in the folder of the simulation.\n",
+    "Let's have a look at them"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Image\n",
+    "\n",
+    "# datadir is the top-level directory that contains that data for\n",
+    "# a given simulation. In the first cell of this notebook we define\n",
+    "# get_datadir() as a helper function to find the path.\n",
+    "datadir = get_datadir()\n",
+    "Image(filename=os.path.join(datadir, \"rho_maximum.png\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Image(filename=os.path.join(datadir, \"rho_xy.png\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "While the examples are handy and have lots of options, often we want full control. For that, we use `kuibit` as a library. Let's see how we can make plots similar to the ones we generated with the examples. First, we import what we need:"
    ]
   },
   {
@@ -741,43 +865,20 @@
     "# This cell enables inline plotting in the notebook\n",
     "%matplotlib inline\n",
     "\n",
-    "import matplotlib\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "# show the most recent segment directory that Cactus stored its output files in\n",
-    "./simfactory/bin/sim get-output-dir tov_ET"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# store output directory location for later use\n",
-    "# in ipython you can also use this:\n",
-    "# outdir = ! ./simfactory/bin/sim get-output-dir tov_ET\n",
-    "# outdir = outdir[0]\n",
-    "import os\n",
-    "outdir = os.popen(\"./simfactory/bin/sim get-output-dir tov_ET\").read().rstrip(\"\\n\")\n",
+    "# In this tutorial, we also need to reload the userbase variable\n",
+    "# (see comments above on PYTHONUSERBASE)\n",
+    "reload_userbasepath()\n",
     "\n",
-    "print (\"Output is written to\", outdir)"
+    "import matplotlib.pyplot as plt\n",
+    "from kuibit.simdir import SimDir\n",
+    "import kuibit.visualize_matplotlib as viz"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Numpy has a routine called genfromtxt() which is an extremely efficient reader of textual arrays of floating point numbers. This is well-suited to Cactus .asc files."
+    "The main interface to simulation data in `kuibit` is the `SimDir`. It contains all the information that `kuibit` can extract from the output. `SimDir` takes as input the top level folder of the output. "
    ]
   },
   {
@@ -786,15 +887,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# format of the outdir path: SIMULATION-NAME/output-NNNN/PARFILE-NAME\n",
-    "lin_data = np.genfromtxt(outdir+\"/tov_ET/hydrobase-rho.maximum.asc\")"
+    "sim = SimDir(datadir)\n",
+    "# This sill print a list with all the data available\n",
+    "print(sim)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is all you need to do to plot the data once you've loaded it. Note, this uses Python array notation to grab columns 1 and 2 of the data file."
+    "Let's plot the maximum pressure and compare it with the pressure as computed from the maximum density."
    ]
   },
   {
@@ -803,10 +905,81 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.plot(lin_data[:,1],lin_data[:,2]/lin_data[0,2], label=\"central density\")\n",
-    "plt.xlabel(r'$t$ [$M_{\\odot}$]');\n",
-    "plt.ylabel(r'$\\rho_c / \\rho_c(0)$');\n",
-    "plt.legend();"
+    "rho = sim.timeseries.maximum['rho']\n",
+    "press = sim.timeseries.maximum['press']\n",
+    "\n",
+    "# Polytropic constants\n",
+    "K, Gamma = 100, 2\n",
+    "\n",
+    "# Timeseries in kuibit support all the algebraic operations\n",
+    "cold_press = K * rho**Gamma\n",
+    "\n",
+    "plt.ylabel(\"Pressure\")\n",
+    "plt.xlabel(\"Time\")\n",
+    "plt.plot(cold_press, label=\"cold_press\")\n",
+    "plt.plot(press, label=\"press\", ls=\"dashed\")\n",
+    "plt.legend()\n",
+    "\n",
+    "max_diff = abs(press - cold_press).max()\n",
+    "\n",
+    "print(f\"Max difference {max_diff:.3e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's plot an equatorial slice of the rest-mass density at the initial iteration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iteration_number = 0\n",
+    "rho_xy = sim.gridfunctions.xy[\"rho\"][iteration_number]\n",
+    "\n",
+    "# We cannot plot rho_xy directly because it contains all\n",
+    "# the information for the various refinement levels. \n",
+    "# We need to resample the data onto a uniform grid.\n",
+    "\n",
+    "# shape is the resolution at which we resample\n",
+    "# x0, x1 are the bottom left and top right coordiantes\n",
+    "# that we want to consider\n",
+    "\n",
+    "# Here we choose x0=[0,0] because we have reflection \n",
+    "# symmetry\n",
+    "\n",
+    "# resample=True activates multilinear resampling\n",
+    "\n",
+    "rho_xy_unif = rho_xy.to_UniformGridData(shape=[100, 100], \n",
+    "                                        x0=[0,0],\n",
+    "                                        x1=[10, 10],\n",
+    "                                        resample=True)\n",
+    "\n",
+    "# Undo reflection symmetry on the x axis\n",
+    "rho_xy_unif.reflection_symmetry_undo(dimension=0)\n",
+    "# Undo reflection symmetry on the y axis\n",
+    "rho_xy_unif.reflection_symmetry_undo(dimension=1)\n",
+    "\n",
+    "viz.plot_color(rho_xy_unif,\n",
+    "               logscale=True,\n",
+    "               colorbar=True,\n",
+    "               label=\"rho\",\n",
+    "               xlabel=\"x\",\n",
+    "               ylabel=\"y\",\n",
+    "              )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The image is pixelated because the resolution of our simulation is very low.\n",
+    "\n",
+    "Finally, we can compare our data with some reference values."
    ]
   },
   {
@@ -816,6 +989,7 @@
    "outputs": [],
    "source": [
     "# this cell shows the expected plot using previously stored data\n",
+    "import numpy as np\n",
     "\n",
     "# reconstruct plot data from saved strings\n",
     "(quant_diff_s, minval, maxval, delta_t) = \\\n",
@@ -828,7 +1002,7 @@
     "# plot them, including your results if you have them\n",
     "plt.plot(rec_time, rec_vals/rec_vals[0],\n",
     "         label=\"central density (stored values)\")\n",
-    "try: plt.plot(lin_data[:,1],lin_data[:,2]/lin_data[0,2], label=\"central density (your results)\")\n",
+    "try: plt.plot(rho/rho(0), label=\"central density (your results)\")\n",
     "except: pass\n",
     "plt.xlabel(r'$t$ [$M_{\\odot}$]');\n",
     "plt.ylabel(r'$\\rho_c / \\rho_c(0)$');\n",
@@ -872,13 +1046,6 @@
     "# create a low fidelity representation of every 10th datapoint and output all data a string\n",
     "sparsify(lin_data, 10)    "
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -897,7 +1064,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.10.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
As briefly discussed in ET call on Thursday 14 Jan, I added `kuibit` to `CactusTutorial`. 

In the tutorial, I am showing two different ways to use of `kuibit` to plot a timeseries and a grid function. The first is using existing examples, the second is writing your custom Python code, where I also highlight how you can make some basic manipulations. Of course, this barely scratches the surface of what `kuibit can do.